### PR TITLE
ignore loadbalancer listener to prevent errors on ressource collector

### DIFF
--- a/data/resource_collector.py
+++ b/data/resource_collector.py
@@ -689,7 +689,10 @@ def handler():
         region_namespace = {'Region': region, 'Namespaces' : cw_custom_namespace_retriever(config) }
         region_namespaces['RegionNamespaces'].append(region_namespace)
         for resource in resources:
-            decorated_resources.append(router(resource, config))
+            if 'elasticloadbalancing' in resource["ResourceARN"] and ( '/net/' in resource["ResourceARN"] or '/app/' in resource["ResourceARN"] ) and ':listener/' in resource["ResourceARN"]:
+                continue
+            else:
+                decorated_resources.append(router(resource, config))
     cn = open(custom_namespace_file, "w")
     cn.write(json.dumps(region_namespaces, indent=4, default=str))
     cn.close()


### PR DESCRIPTION
*Description of changes:*
I had problems with loadbalancer listeners, as they produce errors in the ressource collector step. Hence I ignored them.
Error was:
```
Got the pagination token
Got the pagination token
Done fetching autoscaling groups
['abc']
['abc', 'xyz']
Done fetching cloudwatch namespaces
This resource is EC2 arn:aws:ec2:REGION:ACCOUNT_ID:instance/i-030c9b32154097763
Done fetching volumes
Instance i-030c9b32154097763 does not have CWAgent
This resource is EC2 arn:aws:ec2:REGION:ACCOUNT_ID:instance/i-013c766a7bdfdaf5d
Done fetching volumes
Instance i-013c766a7bdfdaf5d does not have CWAgent
This resource is ELBv2 arn:aws:elasticloadbalancing:REGION:ACCOUNT_ID:listener/app/lb-name/c0b0259937634568/aba573d50763852a
Traceback (most recent call last):
  File "/path/to/repo/tag-based-cloudwatch-dashboard/data/resource_collector.py", line 701, in <module>
    handler()
  File "/path/to/repo/tag-based-cloudwatch-dashboard/data/resource_collector.py", line 692, in handler
    decorated_resources.append(router(resource, config))
                               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/repo/tag-based-cloudwatch-dashboard/data/resource_collector.py", line 159, in router
    resource = elb2_decorator(resource, config)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/repo/tag-based-cloudwatch-dashboard/data/resource_collector.py", line 484, in elb2_decorator
    response = elb.describe_load_balancers(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/botocore/client.py", line 553, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/botocore/client.py", line 1009, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the DescribeLoadBalancers operation: 'arn:aws:elasticloadbalancing:REGION:ACCOUNT_ID:listener/app/lb-name/c0b0259937634568/aba573d50763852a' is not a valid load balancer ARN
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
